### PR TITLE
deprecation warnings

### DIFF
--- a/gatsby-theme-blog-remix/src/components/NavLinks.js
+++ b/gatsby-theme-blog-remix/src/components/NavLinks.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useStaticQuery } from "gatsby";
+import { graphql, Link, useStaticQuery } from "gatsby";
 
 /* Shadow me to change the Navigation Links */
 export default function NavLinks({ styles }) {

--- a/gatsby-theme-blog-remix/src/templates/post.js
+++ b/gatsby-theme-blog-remix/src/templates/post.js
@@ -3,7 +3,7 @@ import { graphql } from "gatsby"
 
 import Post from "../components/post"
 
-export default ({ pathContext: { previous, next }, location, data }) => (
+export default ({ pageContext: { previous, next }, location, data }) => (
   <Post data={data} location={location} previous={previous} next={next} />
 )
 

--- a/gatsby-theme-blog-remix/src/templates/posts.js
+++ b/gatsby-theme-blog-remix/src/templates/posts.js
@@ -3,7 +3,7 @@ import React from "react"
 import Posts from "../components/posts"
 
 export default ({
-  pathContext: { posts, siteTitle, socialLinks },
+  pageContext: { posts, siteTitle, socialLinks },
   location,
 }) => (
   <Posts


### PR DESCRIPTION
This PR contains 2 commits to remove **deprecation warnings** thrown by Gatsby.
First commit of this PR removes usage of global `graphql` tag by importing it ([Doc Reference](https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#import-graphql-from-gatsby)).
Second commit renames `pathContext` prop to `pageContext` ([Doc Reference](https://gatsby.dev/pathContext)).